### PR TITLE
test: adiciona testes unitários para validação e criação de transações

### DIFF
--- a/tests/Fluxus.Unit/Application/Features/Transactions/CreateTransaction/CreateTransactionHandlerTests.cs
+++ b/tests/Fluxus.Unit/Application/Features/Transactions/CreateTransaction/CreateTransactionHandlerTests.cs
@@ -1,0 +1,56 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using Fluxus.Application.Features.Transactions.CreateTransaction;
+using Fluxus.Domain.Entities;
+using Fluxus.Application.Domain.Repositories;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+using Fluxus.Unit.Application.TestData;
+
+namespace Fluxus.UnitTests.Application.Features.Transactions.CreateTransaction
+{
+    public class CreateTransactionHandlerTests
+    {
+        private readonly ITransactionRepository _repository;
+        private readonly IMapper _mapper;
+        private readonly CreateTransactionHandler _handler;
+
+        public CreateTransactionHandlerTests()
+        {
+            _repository = Substitute.For<ITransactionRepository>();
+            _mapper = Substitute.For<IMapper>();
+            _handler = new CreateTransactionHandler(_repository, _mapper);
+        }
+
+        [Fact]
+        public async Task Should_Save_Transaction_When_Command_Is_Valid()
+        {
+            // Arrange
+            var command = CreateTransactionHandlerTestData.GenerateValidCommand();
+            var transaction = CreateTransactionHandlerTestData.GenerateExpectedTransaction(command);
+            var resultDto = new CreateTransactionResult { Id = transaction.Id };
+
+            _mapper.Map<Transaction>(command).Returns(transaction);
+            _repository.AddAsync(Arg.Any<Transaction>(), Arg.Any<CancellationToken>())
+                    .Returns(callInfo => Task.FromResult(callInfo.ArgAt<Transaction>(0)));
+            _mapper.Map<CreateTransactionResult>(transaction).Returns(resultDto);
+
+            // Act
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Id.Should().Be(transaction.Id);
+
+            await _repository.Received(1).AddAsync(Arg.Is<Transaction>(t =>
+                t.Amount == command.Amount &&
+                t.Type == command.Type &&
+                t.Description == command.Description &&
+                t.Date == command.Date &&
+                t.UserId == command.UserId
+            ), Arg.Any<CancellationToken>());
+        }
+    }
+}

--- a/tests/Fluxus.Unit/Application/Features/Transactions/CreateTransaction/CreateTransactionValidatorTests.cs
+++ b/tests/Fluxus.Unit/Application/Features/Transactions/CreateTransaction/CreateTransactionValidatorTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Bogus;
+using FluentAssertions;
+using Fluxus.Application.Features.Transactions.CreateTransaction;
+using Fluxus.Domain.Enums;
+using Xunit;
+
+namespace Fluxus.UnitTests.Application.Features.Transactions.CreateTransaction
+{
+    public class CreateTransactionValidatorTests
+    {
+        private readonly CreateTransactionValidator _validator;
+        private readonly Faker _faker;
+
+        public CreateTransactionValidatorTests()
+        {
+            _validator = new CreateTransactionValidator();
+            _faker = new Faker("pt_BR");
+        }
+
+        [Fact]
+        public void Should_Have_Error_When_Date_Is_In_The_Future()
+        {
+            // Arrange
+            var command = new CreateTransactionCommand
+            {
+                Amount = 100,
+                Type = TransactionType.Credit,
+                Description = _faker.Lorem.Sentence(),
+                Date = DateTime.Today.AddDays(1),
+                UserId = Guid.NewGuid()
+            };
+
+            // Act
+            var result = _validator.Validate(command);
+
+            // Assert
+            result.IsValid.Should().BeFalse();
+            result.Errors.Should().ContainSingle(e =>
+                e.PropertyName == "Date" &&
+                e.ErrorMessage == "A data da transação não pode ser no futuro.");
+        }
+
+        [Fact]
+        public void Should_Not_Have_Errors_When_Date_Is_Today_Or_Past()
+        {
+            // Arrange
+            var command = new CreateTransactionCommand
+            {
+                Amount = 50,
+                Type = TransactionType.Debit,
+                Description = _faker.Commerce.ProductName(),
+                Date = DateTime.Today,
+                UserId = Guid.NewGuid()
+            };
+
+            // Act
+            var result = _validator.Validate(command);
+
+            // Assert
+            result.IsValid.Should().BeTrue();
+        }
+    }
+}

--- a/tests/Fluxus.Unit/Application/TestData/CreateTransactionHandlerTestData.cs
+++ b/tests/Fluxus.Unit/Application/TestData/CreateTransactionHandlerTestData.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Bogus;
+using Fluxus.Application.Features.Transactions.CreateTransaction;
+using Fluxus.Domain.Entities;
+using Fluxus.Domain.Enums;
+
+namespace Fluxus.Unit.Application.TestData
+{
+    public static class CreateTransactionHandlerTestData
+    {
+        private static readonly Faker Faker = new("pt_BR");
+
+        public static CreateTransactionCommand GenerateValidCommand()
+        {
+            return new CreateTransactionCommand
+            {
+                Amount = Faker.Finance.Amount(1, 1000),
+                Type = Faker.PickRandom<TransactionType>(),
+                Description = Faker.Commerce.ProductName(),
+                Date = DateTime.Today,
+                UserId = Guid.NewGuid()
+            };
+        }
+
+        public static Transaction GenerateExpectedTransaction(CreateTransactionCommand command)
+        {
+            return new Transaction
+            {
+                Id = Guid.NewGuid(),
+                Amount = command.Amount,
+                Type = command.Type,
+                Description = command.Description,
+                Date = command.Date,
+                UserId = command.UserId
+            };
+        }
+    }
+}


### PR DESCRIPTION
# Adiciona testes unitários para validação e criação de transações

Esta PR inclui os testes unitários da feature `CreateTransaction`, que complementam a entrega feita anteriormente na branch `feature/create-transaction`.

---

## Testes incluídos

### Application
- `CreateTransactionValidatorTests`: valida regra de que a data da transação não pode ser futura
- `CreateTransactionHandlerTests`: verifica o fluxo do handler com mapeamento e persistência

### TestData
- `CreateTransactionHandlerTestData`: fornece comandos e entidades usando `Bogus`

---

## Tecnologias utilizadas

- `xUnit`
- `FluentAssertions`
- `NSubstitute`
- `Bogus`

---

## Organização dos testes

Os testes seguem a estrutura da aplicação, com `TestData` separado e testes organizados por feature:

