### PR TITLE
test: adiciona testes unitários para autenticação de usuários

### DIFF
--- a/tests/Fluxus.Unit/Application/Features/Auth/AuthenticateUser/AuthenticateUserHandlerTests.cs
+++ b/tests/Fluxus.Unit/Application/Features/Auth/AuthenticateUser/AuthenticateUserHandlerTests.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Fluxus.Application.Features.Auth.AuthenticateUser;
+using Fluxus.Common.Security.Interfaces;
+using Fluxus.Application.Domain.Repositories;
+using Fluxus.Domain.Entities;
+using Fluxus.UnitTests.Application.TestData;
+using NSubstitute;
+using Xunit;
+
+namespace Fluxus.UnitTests.Application.Features.Auth.AuthenticateUser
+{
+    public class AuthenticateUserHandlerTests
+    {
+        private readonly IUserRepository _userRepository;
+        private readonly IPasswordHasher _passwordHasher;
+        private readonly IJwtTokenGenerator _jwtTokenGenerator;
+        private readonly AuthenticateUserHandler _handler;
+
+        public AuthenticateUserHandlerTests()
+        {
+            _userRepository = Substitute.For<IUserRepository>();
+            _passwordHasher = Substitute.For<IPasswordHasher>();
+            _jwtTokenGenerator = Substitute.For<IJwtTokenGenerator>();
+
+            _handler = new AuthenticateUserHandler(
+                _userRepository,
+                _passwordHasher,
+                _jwtTokenGenerator
+            );
+        }
+
+        [Fact]
+        public async Task Should_Return_Token_When_Credentials_Are_Valid()
+        {
+            // Arrange
+            var command = AuthenticateUserHandlerTestData.GenerateValidCommand();
+            var user = AuthenticateUserHandlerTestData.GenerateUser(command.Email, "hashed-password");
+
+            _userRepository.GetByEmailAsync(command.Email, Arg.Any<CancellationToken>())
+                           .Returns(user);
+
+            _passwordHasher.VerifyPassword(command.Password, user.PasswordHash)
+                           .Returns(true);
+
+            _jwtTokenGenerator.GenerateToken(user).Returns("fake-token");
+
+            // Act
+            var result = await _handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Token.Should().Be("fake-token");
+            result.Email.Should().Be(user.Email);
+            result.Name.Should().Be(user.Name);
+            result.Role.Should().Be(user.Role);
+            result.Id.Should().Be(user.Id);
+        }
+
+        [Fact]
+        public async Task Should_Throw_When_User_Not_Found()
+        {
+            // Arrange
+            var command = AuthenticateUserHandlerTestData.GenerateValidCommand();
+
+            _userRepository.GetByEmailAsync(command.Email, Arg.Any<CancellationToken>())
+                           .Returns((User?)null);
+
+            // Act
+            var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            await act.Should().ThrowAsync<UnauthorizedAccessException>()
+                     .WithMessage("Credenciais inválidas.");
+        }
+
+        [Fact]
+        public async Task Should_Throw_When_Password_Is_Invalid()
+        {
+            // Arrange
+            var command = AuthenticateUserHandlerTestData.GenerateValidCommand();
+            var user = AuthenticateUserHandlerTestData.GenerateUser(command.Email, "hashed-password");
+
+            _userRepository.GetByEmailAsync(command.Email, Arg.Any<CancellationToken>())
+                           .Returns(user);
+
+            _passwordHasher.VerifyPassword(command.Password, user.PasswordHash)
+                           .Returns(false);
+
+            // Act
+            var act = async () => await _handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            await act.Should().ThrowAsync<UnauthorizedAccessException>()
+                     .WithMessage("Credenciais inválidas.");
+        }
+    }
+}

--- a/tests/Fluxus.Unit/Application/Features/Auth/AuthenticateUser/AuthenticateUserValidatorTests.cs
+++ b/tests/Fluxus.Unit/Application/Features/Auth/AuthenticateUser/AuthenticateUserValidatorTests.cs
@@ -1,0 +1,78 @@
+﻿using Bogus;
+using FluentAssertions;
+using Fluxus.Application.Features.Auth.AuthenticateUser;
+using Xunit;
+
+namespace Fluxus.UnitTests.Application.Features.Auth.AuthenticateUser
+{
+    public class AuthenticateUserValidatorTests
+    {
+        private readonly AuthenticateUserValidator _validator;
+        private readonly Faker _faker;
+
+        public AuthenticateUserValidatorTests()
+        {
+            _validator = new AuthenticateUserValidator();
+            _faker = new Faker("pt_BR");
+        }
+
+        [Fact]
+        public void Should_Have_Error_When_Email_Is_Empty()
+        {
+            var command = new AuthenticateUserCommand
+            {
+                Email = string.Empty,
+                Password = _faker.Internet.Password()
+            };
+
+            var result = _validator.Validate(command);
+
+            result.IsValid.Should().BeFalse();
+            result.Errors.Should().Contain(e => e.PropertyName == "Email");
+        }
+
+        [Fact]
+        public void Should_Have_Error_When_Email_Is_Invalid()
+        {
+            var command = new AuthenticateUserCommand
+            {
+                Email = "email-invalido",
+                Password = _faker.Internet.Password()
+            };
+
+            var result = _validator.Validate(command);
+
+            result.IsValid.Should().BeFalse();
+            result.Errors.Should().Contain(e => e.PropertyName == "Email");
+        }
+
+        [Fact]
+        public void Should_Have_Error_When_Password_Is_Empty()
+        {
+            var command = new AuthenticateUserCommand
+            {
+                Email = _faker.Internet.Email(),
+                Password = string.Empty
+            };
+
+            var result = _validator.Validate(command);
+
+            result.IsValid.Should().BeFalse();
+            result.Errors.Should().Contain(e => e.PropertyName == "Password");
+        }
+
+        [Fact]
+        public void Should_Pass_When_Email_And_Password_Are_Valid()
+        {
+            var command = new AuthenticateUserCommand
+            {
+                Email = _faker.Internet.Email(),
+                Password = _faker.Internet.Password()
+            };
+
+            var result = _validator.Validate(command);
+
+            result.IsValid.Should().BeTrue();
+        }
+    }
+}

--- a/tests/Fluxus.Unit/Application/TestData/AuthenticateUserHandlerTestData.cs
+++ b/tests/Fluxus.Unit/Application/TestData/AuthenticateUserHandlerTestData.cs
@@ -1,0 +1,32 @@
+﻿using Bogus;
+using Fluxus.Application.Features.Auth.AuthenticateUser;
+using Fluxus.Domain.Entities;
+
+namespace Fluxus.UnitTests.Application.TestData
+{
+    public static class AuthenticateUserHandlerTestData
+    {
+        private static readonly Faker Faker = new("pt_BR");
+
+        public static AuthenticateUserCommand GenerateValidCommand(string? email = null, string? password = null)
+        {
+            return new AuthenticateUserCommand
+            {
+                Email = email ?? Faker.Internet.Email(),
+                Password = password ?? Faker.Internet.Password()
+            };
+        }
+
+        public static User GenerateUser(string email, string passwordHash)
+        {
+            return new User
+            {
+                Id = Guid.NewGuid(),
+                Name = Faker.Name.FullName(),
+                Email = email,
+                PasswordHash = passwordHash,
+                Role = "User"
+            };
+        }
+    }
+}


### PR DESCRIPTION
# Testes unitários para autenticação de usuários

Esta PR adiciona testes unitários completos para a feature de autenticação (`AuthenticateUser`), garantindo a validação correta de entradas e o comportamento esperado do handler.

---

## Testes incluídos

### Application

#### AuthenticateUserValidatorTests
- Valida que:
  - E-mail é obrigatório e deve ser válido
  - Senha é obrigatória

#### AuthenticateUserHandlerTests
- Retorna token válido com credenciais corretas
- Lança exceção se e-mail não for encontrado
- Lança exceção se senha for inválida

### TestData
- `AuthenticateUserHandlerTestData`: gera comandos e usuários de teste com Bogus

---

## Tecnologias utilizadas

- `xUnit`
- `FluentAssertions`
- `NSubstitute`
- `Bogus`

---