### PR TITLE
refactor: remove propriedade Role do usuário

### DIFF
--- a/src/Fluxus.Application/Features/Auth/AuthenticateUser/AuthenticateUserHandler.cs
+++ b/src/Fluxus.Application/Features/Auth/AuthenticateUser/AuthenticateUserHandler.cs
@@ -34,7 +34,6 @@ public class AuthenticateUserHandler : IRequestHandler<AuthenticateUserCommand, 
             Id = user.Id,
             Name = user.Name,
             Email = user.Email,
-            Role = user.Role,
             Token = token
         };
     }

--- a/src/Fluxus.Application/Features/Auth/AuthenticateUser/AuthenticateUserResult.cs
+++ b/src/Fluxus.Application/Features/Auth/AuthenticateUser/AuthenticateUserResult.cs
@@ -5,6 +5,5 @@ public sealed class AuthenticateUserResult
     public Guid Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string Email { get; set; } = string.Empty;
-    public string Role { get; set; } = string.Empty;
     public string Token { get; set; } = string.Empty;
 }

--- a/src/Fluxus.Common/Security/Interfaces/IUser.cs
+++ b/src/Fluxus.Common/Security/Interfaces/IUser.cs
@@ -10,6 +10,5 @@ namespace Fluxus.Common.Security.Interfaces
         Guid Id { get; }
         string Name { get; }
         string Email { get; }
-        string Role { get; }
     }
 }

--- a/src/Fluxus.Common/Security/Services/JwtTokenGenerator.cs
+++ b/src/Fluxus.Common/Security/Services/JwtTokenGenerator.cs
@@ -26,8 +26,7 @@ namespace Fluxus.Common.Security.Services
             {
                 new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
                 new Claim(JwtRegisteredClaimNames.Email, user.Email),
-                new Claim(ClaimTypes.Name, user.Name),
-                new Claim(ClaimTypes.Role, user.Role)
+                new Claim(ClaimTypes.Name, user.Name)
             };
 
             var credentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256);

--- a/src/Fluxus.Domain/Entities/User.cs
+++ b/src/Fluxus.Domain/Entities/User.cs
@@ -15,8 +15,5 @@ namespace Fluxus.Domain.Entities
 
         [Required]
         public string PasswordHash { get; set; } = string.Empty;
-
-        [Required]
-        public string Role { get; set; } = "User";
     }
 }

--- a/src/Fluxus.ORM/Mapping/UserConfiguration.cs
+++ b/src/Fluxus.ORM/Mapping/UserConfiguration.cs
@@ -27,10 +27,6 @@ namespace Fluxus.ORM.Mappings
             builder.Property(u => u.PasswordHash)
                 .IsRequired()
                 .HasMaxLength(200);
-
-            builder.Property(u => u.Role)
-                .IsRequired()
-                .HasMaxLength(50);
         }
     }
 }

--- a/src/Fluxus.ORM/Migrations/20250328192319_RemoveUserRole.Designer.cs
+++ b/src/Fluxus.ORM/Migrations/20250328192319_RemoveUserRole.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Fluxus.ORM;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Fluxus.ORM.Migrations
 {
     [DbContext(typeof(DefaultContext))]
-    partial class DefaultContextModelSnapshot : ModelSnapshot
+    [Migration("20250328192319_RemoveUserRole")]
+    partial class RemoveUserRole
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Fluxus.ORM/Migrations/20250328192319_RemoveUserRole.cs
+++ b/src/Fluxus.ORM/Migrations/20250328192319_RemoveUserRole.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Fluxus.ORM.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveUserRole : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Role",
+                table: "Users");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Role",
+                table: "Users",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "");
+        }
+    }
+}

--- a/src/Fluxus.ORM/Seed/DefaultContextSeed.cs
+++ b/src/Fluxus.ORM/Seed/DefaultContextSeed.cs
@@ -14,12 +14,10 @@ namespace Fluxus.ORM.Seed
                 var email = configuration["Seed:AdminEmail"];
                 var password = configuration["Seed:AdminPassword"];
                 var name = configuration["Seed:AdminName"];
-                var role = configuration["Seed:AdminRole"];
 
                 if (string.IsNullOrWhiteSpace(email) ||
                     string.IsNullOrWhiteSpace(password) ||
-                    string.IsNullOrWhiteSpace(name) ||
-                    string.IsNullOrWhiteSpace(role))
+                    string.IsNullOrWhiteSpace(name))
                 {
                     throw new InvalidOperationException("Admin seed values must be provided via configuration.");
                 }
@@ -28,8 +26,7 @@ namespace Fluxus.ORM.Seed
                 {
                     Name = name,
                     Email = email,
-                    PasswordHash = passwordHasher.HashPassword(password),
-                    Role = role
+                    PasswordHash = passwordHasher.HashPassword(password)
                 };
 
                 context.Users.Add(admin);

--- a/src/Fluxus.WebApi/Features/Auth/AuthenticateUserFeature/AuthenticateUserResponse.cs
+++ b/src/Fluxus.WebApi/Features/Auth/AuthenticateUserFeature/AuthenticateUserResponse.cs
@@ -8,6 +8,5 @@
         public string Token { get; set; } = string.Empty;
         public string Email { get; set; } = string.Empty;
         public string Name { get; set; } = string.Empty;
-        public string Role { get; set; } = string.Empty;
     }
 }

--- a/tests/Fluxus.Unit/Application/Features/Auth/AuthenticateUser/AuthenticateUserHandlerTests.cs
+++ b/tests/Fluxus.Unit/Application/Features/Auth/AuthenticateUser/AuthenticateUserHandlerTests.cs
@@ -55,7 +55,6 @@ namespace Fluxus.UnitTests.Application.Features.Auth.AuthenticateUser
             result.Token.Should().Be("fake-token");
             result.Email.Should().Be(user.Email);
             result.Name.Should().Be(user.Name);
-            result.Role.Should().Be(user.Role);
             result.Id.Should().Be(user.Id);
         }
 

--- a/tests/Fluxus.Unit/Application/TestData/AuthenticateUserHandlerTestData.cs
+++ b/tests/Fluxus.Unit/Application/TestData/AuthenticateUserHandlerTestData.cs
@@ -24,8 +24,7 @@ namespace Fluxus.UnitTests.Application.TestData
                 Id = Guid.NewGuid(),
                 Name = Faker.Name.FullName(),
                 Email = email,
-                PasswordHash = passwordHash,
-                Role = "User"
+                PasswordHash = passwordHash
             };
         }
     }


### PR DESCRIPTION
# Refatoração: remoção da propriedade `Role` do usuário

Esta PR remove a propriedade `Role` da entidade `User`, simplificando o modelo de acordo com o escopo do desafio, que descreve um sistema voltado para uso individual (por um comerciante). A aplicação segue protegida por autenticação, mas sem necessidade de múltiplos perfis de acesso.

---

## Alterações realizadas

- Removida a propriedade `Role` da entidade `User`
- Removida a claim de `Role` do token JWT
- Ajustados os testes unitários que utilizavam `Role`
- Atualizada a seed do banco para não incluir `Role`
- Criada migration `RemoveUserRole` para remover a coluna do banco

---

## Justificativa da refatoração

A propriedade `Role` não era utilizada para controle de permissões e não fazia sentido dentro do domínio do sistema, que é voltado para uso individual do próprio comerciante. A remoção mantém o modelo mais limpo, simples e focado.

---

## Testado com sucesso localmente
