### PR TITLE
Feat: Exportação de Relatório Diário em PDF

### DIFF
--- a/src/Fluxus.Application/Features/CashFlows/Reports/GenerateDailyCashFlowReport/GenerateDailyCashFlowReportHandler.cs
+++ b/src/Fluxus.Application/Features/CashFlows/Reports/GenerateDailyCashFlowReport/GenerateDailyCashFlowReportHandler.cs
@@ -1,0 +1,63 @@
+﻿using AutoMapper;
+using Fluxus.Application.Domain.Repositories;
+using Fluxus.Common.Reporting.Constants;
+using Fluxus.Common.Reporting.Interfaces;
+using Fluxus.Common.Reporting.Models;
+using Fluxus.Common.Reporting.Services.Documents;
+using MediatR;
+
+namespace Fluxus.Application.Features.CashFlows.DailyCashFlow.Reports.GenerateDailyCashFlowReport
+{
+    public class GenerateDailyCashFlowReportHandler
+        : IRequestHandler<GenerateDailyCashFlowReportQuery, GenerateDailyCashFlowReportResult>
+    {
+        private readonly IDailyConsolidationRepository _repository;
+        private readonly IPdfReportGenerator _reportGenerator;
+        private readonly IMapper _mapper;
+
+        public GenerateDailyCashFlowReportHandler(
+            IDailyConsolidationRepository repository,
+            IPdfReportGenerator reportGenerator,
+            IMapper mapper)
+        {
+            _repository = repository;
+            _reportGenerator = reportGenerator;
+            _mapper = mapper;
+        }
+
+        public async Task<GenerateDailyCashFlowReportResult> Handle(
+            GenerateDailyCashFlowReportQuery request,
+            CancellationToken cancellationToken)
+        {
+            var consolidations = await _repository.GetAllByUserAsync(request.UserId, cancellationToken);
+
+            if (request.DateFrom.HasValue)
+                consolidations = consolidations.Where(x => x.Date >= request.DateFrom.Value);
+
+            if (request.DateTo.HasValue)
+                consolidations = consolidations.Where(x => x.Date <= request.DateTo.Value);
+
+            var sortedConsolidations = consolidations.OrderBy(x => x.Date).ToList();
+
+            var items = _mapper.Map<List<DailyCashFlowReportModel>>(sortedConsolidations);
+
+            decimal accumulated = 0;
+            foreach (var item in items)
+            {
+                accumulated += item.DailyBalance;
+                item.AccumulatedBalance = accumulated;
+            }
+
+            var document = new DailyCashFlowReportDocument(items);
+
+            var pdfBytes = await _reportGenerator.GenerateAsync(document, cancellationToken);
+
+            return new GenerateDailyCashFlowReportResult
+            {
+                FileName = ReportMetadata.DailyCashFlowFileName,
+                FileContent = pdfBytes,
+                ContentType = ReportMetadata.PdfContentType
+            };
+        }
+    }
+}

--- a/src/Fluxus.Application/Features/CashFlows/Reports/GenerateDailyCashFlowReport/GenerateDailyCashFlowReportItem.cs
+++ b/src/Fluxus.Application/Features/CashFlows/Reports/GenerateDailyCashFlowReport/GenerateDailyCashFlowReportItem.cs
@@ -1,0 +1,11 @@
+﻿namespace Fluxus.Application.Features.CashFlows.DailyCashFlow.Reports.GenerateDailyCashFlowReport
+{
+    public class GenerateDailyCashFlowReportItem
+    {
+        public DateOnly Date { get; set; }
+        public decimal TotalCredits { get; set; }
+        public decimal TotalDebits { get; set; }
+        public decimal DailyBalance => TotalCredits - TotalDebits;
+        public decimal AccumulatedBalance { get; set; }
+    }
+}

--- a/src/Fluxus.Application/Features/CashFlows/Reports/GenerateDailyCashFlowReport/GenerateDailyCashFlowReportProfile.cs
+++ b/src/Fluxus.Application/Features/CashFlows/Reports/GenerateDailyCashFlowReport/GenerateDailyCashFlowReportProfile.cs
@@ -1,0 +1,15 @@
+﻿using AutoMapper;
+using Fluxus.Common.Reporting.Models;
+using Fluxus.Domain.Entities;
+
+namespace Fluxus.Application.Features.CashFlows.DailyCashFlow.Reports.GenerateDailyCashFlowReport
+{
+    public class GenerateDailyCashFlowReportProfile : Profile
+    {
+        public GenerateDailyCashFlowReportProfile()
+        {
+            CreateMap<DailyConsolidation, DailyCashFlowReportModel>()
+                .ForMember(dest => dest.AccumulatedBalance, opt => opt.Ignore());
+        }
+    }
+}

--- a/src/Fluxus.Application/Features/CashFlows/Reports/GenerateDailyCashFlowReport/GenerateDailyCashFlowReportQuery.cs
+++ b/src/Fluxus.Application/Features/CashFlows/Reports/GenerateDailyCashFlowReport/GenerateDailyCashFlowReportQuery.cs
@@ -1,0 +1,11 @@
+﻿using MediatR;
+
+namespace Fluxus.Application.Features.CashFlows.DailyCashFlow.Reports.GenerateDailyCashFlowReport
+{
+    public class GenerateDailyCashFlowReportQuery : IRequest<GenerateDailyCashFlowReportResult>
+    {
+        public Guid UserId { get; set; }
+        public DateOnly? DateFrom { get; set; }
+        public DateOnly? DateTo { get; set; }
+    }
+}

--- a/src/Fluxus.Application/Features/CashFlows/Reports/GenerateDailyCashFlowReport/GenerateDailyCashFlowReportQueryValidator.cs
+++ b/src/Fluxus.Application/Features/CashFlows/Reports/GenerateDailyCashFlowReport/GenerateDailyCashFlowReportQueryValidator.cs
@@ -1,0 +1,14 @@
+﻿using FluentValidation;
+
+namespace Fluxus.Application.Features.CashFlows.DailyCashFlow.Reports.GenerateDailyCashFlowReport
+{
+    public class GenerateDailyCashFlowReportQueryValidator : AbstractValidator<GenerateDailyCashFlowReportQuery>
+    {
+        public GenerateDailyCashFlowReportQueryValidator()
+        {
+            RuleFor(x => x)
+                .Must(x => !x.DateTo.HasValue || x.DateFrom <= x.DateTo)
+                .WithMessage("A data inicial deve ser anterior ou igual à data final.");
+        }
+    }
+}

--- a/src/Fluxus.Application/Features/CashFlows/Reports/GenerateDailyCashFlowReport/GenerateDailyCashFlowReportResult.cs
+++ b/src/Fluxus.Application/Features/CashFlows/Reports/GenerateDailyCashFlowReport/GenerateDailyCashFlowReportResult.cs
@@ -1,0 +1,9 @@
+﻿namespace Fluxus.Application.Features.CashFlows.DailyCashFlow.Reports.GenerateDailyCashFlowReport
+{
+    public class GenerateDailyCashFlowReportResult
+    {
+        public string FileName { get; set; } = string.Empty;
+        public byte[] FileContent { get; set; } = Array.Empty<byte>();
+        public string ContentType { get; set; } = "application/pdf";
+    }
+}

--- a/src/Fluxus.Common/Fluxus.Common.csproj
+++ b/src/Fluxus.Common/Fluxus.Common.csproj
@@ -13,12 +13,14 @@
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
 		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.10" />
+		<PackageReference Include="QuestPDF" Version="2025.1.7" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
 		<PackageReference Include="FluentValidation" Version="11.10.0" />
 		<PackageReference Include="MediatR" Version="12.4.1" />
+		<PackageReference Include="RazorLight" Version="2.3.1" />
 		<PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
 		<PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
 		<PackageReference Include="Serilog.Exceptions.EntityFrameworkCore" Version="8.4.0" />
@@ -27,5 +29,6 @@
 		<PackageReference Include="Serilog.Enrichers.ExceptionData" Version="1.0.0" />
 		<PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
 	</ItemGroup>
+
 
 </Project>

--- a/src/Fluxus.Common/Reporting/Components/DailyCashFlowTableComponent.cs
+++ b/src/Fluxus.Common/Reporting/Components/DailyCashFlowTableComponent.cs
@@ -1,0 +1,62 @@
+﻿using Fluxus.Common.Reporting.Constants;
+using Fluxus.Common.Reporting.Models;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+
+namespace Fluxus.Common.Reporting.Services.Components
+{
+    public class DailyCashFlowTableComponent : IComponent
+    {
+        private readonly IEnumerable<DailyCashFlowReportModel> _items;
+
+        public DailyCashFlowTableComponent(IEnumerable<DailyCashFlowReportModel> items)
+        {
+            _items = items;
+        }
+
+        public void Compose(IContainer container)
+        {
+            container
+                .Table(table =>
+                {
+                    table.ColumnsDefinition(columns =>
+                    {
+                        columns.RelativeColumn(2); 
+                        columns.RelativeColumn();  
+                        columns.RelativeColumn();  
+                        columns.RelativeColumn();  
+                        columns.RelativeColumn();  
+                    });
+
+                    // Header
+                    table.Header(header =>
+                    {
+                        header.Cell().Element(CellStyle).Text(ReportLabels.Date).SemiBold();
+                        header.Cell().Element(CellStyle).Text(ReportLabels.Credits).SemiBold();
+                        header.Cell().Element(CellStyle).Text(ReportLabels.Debits).SemiBold();
+                        header.Cell().Element(CellStyle).Text(ReportLabels.DailyBalance).SemiBold();
+                        header.Cell().Element(CellStyle).Text(ReportLabels.AccumulatedBalance).SemiBold();
+                    });
+
+                    // Data
+                    foreach (var item in _items)
+                    {
+                        table.Cell().Element(CellStyle).Text(item.Date.ToString("dd/MM/yyyy"));
+                        table.Cell().Element(CellStyle).Text(item.TotalCredits.ToString("C"));
+                        table.Cell().Element(CellStyle).Text(item.TotalDebits.ToString("C"));
+                        table.Cell().Element(CellStyle).Text(item.DailyBalance.ToString("C"));
+                        table.Cell().Element(CellStyle).Text(item.AccumulatedBalance.ToString("C"));
+                    }
+
+                    static IContainer CellStyle(IContainer container)
+                    {
+                        return container
+                            .Padding(5)
+                            .BorderBottom(1)
+                            .BorderColor(Colors.Grey.Lighten2);
+                    }
+                });
+        }
+    }
+}

--- a/src/Fluxus.Common/Reporting/Components/ReportHeader.cs
+++ b/src/Fluxus.Common/Reporting/Components/ReportHeader.cs
@@ -1,0 +1,19 @@
+﻿using QuestPDF.Fluent;
+using QuestPDF.Infrastructure;
+using Fluxus.Common.Reporting.Constants;
+
+namespace Fluxus.Common.Reporting.Components
+{
+    public static class ReportHeader
+    {
+        public static void Create(IContainer container)
+        {
+            container
+                .AlignCenter()
+                .Text(ReportMetadata.DailyCashFlowTitle)
+                .FontSize(18)
+                .Bold()
+                .FontColor("#333333");
+        }
+    }
+}

--- a/src/Fluxus.Common/Reporting/Constants/ReportLabels.cs
+++ b/src/Fluxus.Common/Reporting/Constants/ReportLabels.cs
@@ -1,0 +1,11 @@
+﻿namespace Fluxus.Common.Reporting.Constants
+{
+    public static class ReportLabels
+    {
+        public const string Date = "Data";
+        public const string Credits = "Créditos";
+        public const string Debits = "Débitos";
+        public const string DailyBalance = "Saldo do Dia";
+        public const string AccumulatedBalance = "Saldo Acumulado";
+    }
+}

--- a/src/Fluxus.Common/Reporting/Constants/ReportMetadata.cs
+++ b/src/Fluxus.Common/Reporting/Constants/ReportMetadata.cs
@@ -1,0 +1,9 @@
+﻿namespace Fluxus.Common.Reporting.Constants
+{
+    public static class ReportMetadata
+    {
+        public const string DailyCashFlowTitle = "Relatório de Fluxo de Caixa Diário";
+        public const string DailyCashFlowFileName = "fluxo-caixa-diario.pdf";
+        public const string PdfContentType = "application/pdf";
+    }
+}

--- a/src/Fluxus.Common/Reporting/Documents/DailyCashFlowReportDocument.cs
+++ b/src/Fluxus.Common/Reporting/Documents/DailyCashFlowReportDocument.cs
@@ -1,0 +1,46 @@
+﻿using Fluxus.Common.Reporting.Constants;
+using Fluxus.Common.Reporting.Models;
+using Fluxus.Common.Reporting.Services.Components;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+
+namespace Fluxus.Common.Reporting.Services.Documents
+{
+    public class DailyCashFlowReportDocument : IDocument
+    {
+        private readonly IEnumerable<DailyCashFlowReportModel> _items;
+
+        public DailyCashFlowReportDocument(IEnumerable<DailyCashFlowReportModel> items)
+        {
+            _items = items;
+        }
+
+        public DocumentMetadata GetMetadata() => DocumentMetadata.Default;
+
+        public void Compose(IDocumentContainer container)
+        {
+            container.Page(page =>
+            {
+                page.Margin(40);
+
+                page.Header()
+                    .PaddingBottom(20)
+                    .Text(ReportMetadata.DailyCashFlowTitle)
+                    .SemiBold()
+                    .FontSize(18)
+                    .AlignCenter();
+
+                page.Content().Component(new DailyCashFlowTableComponent(_items));
+
+                page.Footer().AlignCenter().Text(text =>
+                {
+                    text.Span("Página ");
+                    text.CurrentPageNumber();
+                    text.Span(" de ");
+                    text.TotalPages();
+                });
+            });
+        }
+    }
+}

--- a/src/Fluxus.Common/Reporting/Interfaces/IPdfReportDocument.cs
+++ b/src/Fluxus.Common/Reporting/Interfaces/IPdfReportDocument.cs
@@ -1,0 +1,9 @@
+﻿using QuestPDF.Infrastructure;
+
+namespace Fluxus.Common.Reporting.Interfaces
+{
+    public interface IPdfReportDocument : IDocument
+    {
+        byte[] GeneratePdf();
+    }
+}

--- a/src/Fluxus.Common/Reporting/Interfaces/IPdfReportGenerator.cs
+++ b/src/Fluxus.Common/Reporting/Interfaces/IPdfReportGenerator.cs
@@ -1,0 +1,9 @@
+﻿using QuestPDF.Infrastructure;
+
+namespace Fluxus.Common.Reporting.Interfaces
+{
+    public interface IPdfReportGenerator
+    {
+        Task<byte[]> GenerateAsync(IDocument document, CancellationToken cancellationToken);
+    }
+}

--- a/src/Fluxus.Common/Reporting/Models/DailyCashFlowReportModel.cs
+++ b/src/Fluxus.Common/Reporting/Models/DailyCashFlowReportModel.cs
@@ -1,0 +1,11 @@
+﻿namespace Fluxus.Common.Reporting.Models
+{
+    public class DailyCashFlowReportModel
+    {
+        public DateOnly Date { get; set; }
+        public decimal TotalCredits { get; set; }
+        public decimal TotalDebits { get; set; }
+        public decimal DailyBalance => TotalCredits - TotalDebits;
+        public decimal AccumulatedBalance { get; set; }
+    }
+}

--- a/src/Fluxus.Common/Reporting/Models/PdfReportRequest.cs
+++ b/src/Fluxus.Common/Reporting/Models/PdfReportRequest.cs
@@ -1,0 +1,9 @@
+﻿namespace Fluxus.Common.Reporting.Models
+{
+    public class PdfReportRequest
+    {
+        public string TemplatePath { get; set; } = string.Empty;
+        public object Data { get; set; } = default!;
+        public string Title { get; set; } = "Relatório";
+    }
+}

--- a/src/Fluxus.Common/Reporting/Models/PdfReportSection.cs
+++ b/src/Fluxus.Common/Reporting/Models/PdfReportSection.cs
@@ -1,0 +1,8 @@
+﻿namespace Fluxus.Common.Reporting.Models
+{
+    public class PdfReportSection
+    {
+        public string Header { get; set; } = string.Empty;
+        public Dictionary<string, string> Rows { get; set; } = new();
+    }
+}

--- a/src/Fluxus.Common/Reporting/Services/PdfReportGenerator.cs
+++ b/src/Fluxus.Common/Reporting/Services/PdfReportGenerator.cs
@@ -1,0 +1,15 @@
+﻿using Fluxus.Common.Reporting.Interfaces;
+using QuestPDF.Fluent;
+using QuestPDF.Infrastructure;
+
+namespace Fluxus.Common.Reporting.Services
+{
+    public class PdfReportGenerator : IPdfReportGenerator
+    {
+        public Task<byte[]> GenerateAsync(IDocument document, CancellationToken cancellationToken = default)
+        {
+            var pdfBytes = document.GeneratePdf();
+            return Task.FromResult(pdfBytes);
+        }
+    }
+}

--- a/src/Fluxus.IoC/ModuleInitializers/ApplicationModuleInitializer.cs
+++ b/src/Fluxus.IoC/ModuleInitializers/ApplicationModuleInitializer.cs
@@ -2,6 +2,8 @@
 using Fluxus.Common.Security.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using Fluxus.Common.Reporting.Interfaces;
+using Fluxus.Common.Reporting.Services;
 
 namespace Fluxus.IoC.ModuleInitializers
 {
@@ -12,6 +14,8 @@ namespace Fluxus.IoC.ModuleInitializers
             builder.Services.AddSingleton<IPasswordHasher, BCryptPasswordHasher>();
             builder.Services.AddHttpContextAccessor();
             builder.Services.AddScoped<IAuthenticatedUser, AuthenticatedUser>();
+            builder.Services.AddScoped<IPdfReportGenerator, PdfReportGenerator>();
+
         }
     }
 }

--- a/src/Fluxus.WebApi/Features/CashFlows/CashFlowReportController.cs
+++ b/src/Fluxus.WebApi/Features/CashFlows/CashFlowReportController.cs
@@ -1,0 +1,43 @@
+﻿using Fluxus.Application.Features.CashFlows.DailyCashFlow.Reports.GenerateDailyCashFlowReport;
+using Fluxus.Common.Reporting.Constants;
+using Fluxus.Common.Security.Interfaces;
+using Fluxus.WebApi.Features.CashFlows.DailyCashFlow.Reports;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Fluxus.WebApi.Features.CashFlows.Reports
+{
+    [Authorize]
+    [ApiController]
+    [Route("api/[controller]")]
+    public class CashFlowReportController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+        private readonly IAuthenticatedUser _authenticatedUser;
+
+        public CashFlowReportController(IMediator mediator, IAuthenticatedUser authenticatedUser)
+        {
+            _mediator = mediator;
+            _authenticatedUser = authenticatedUser;
+        }
+
+        [HttpGet("export")]
+        public async Task<IActionResult> Export([FromQuery] ExportDailyCashFlowReportRequest request, CancellationToken cancellationToken)
+        {
+            var query = new GenerateDailyCashFlowReportQuery
+            {
+                UserId = _authenticatedUser.Id,
+                DateFrom = request.DateFrom,
+                DateTo = request.DateTo
+            };
+
+            var result = await _mediator.Send(query, cancellationToken);
+
+            return new FileContentResult(result.FileContent, result.ContentType)
+            {
+                FileDownloadName = result.FileName
+            };
+        }
+    }
+}

--- a/src/Fluxus.WebApi/Features/CashFlows/DailyCashFlow/Reports/ExportDailyCashFlowReportProfile.cs
+++ b/src/Fluxus.WebApi/Features/CashFlows/DailyCashFlow/Reports/ExportDailyCashFlowReportProfile.cs
@@ -1,0 +1,13 @@
+﻿using AutoMapper;
+using Fluxus.Application.Features.CashFlows.DailyCashFlow.Reports.GenerateDailyCashFlowReport;
+
+namespace Fluxus.WebApi.Features.CashFlows.DailyCashFlow.Reports
+{
+    public class ExportDailyCashFlowReportProfile : Profile
+    {
+        public ExportDailyCashFlowReportProfile()
+        {
+            CreateMap<ExportDailyCashFlowReportRequest, GenerateDailyCashFlowReportQuery>();
+        }
+    }
+}

--- a/src/Fluxus.WebApi/Features/CashFlows/DailyCashFlow/Reports/ExportDailyCashFlowReportRequest.cs
+++ b/src/Fluxus.WebApi/Features/CashFlows/DailyCashFlow/Reports/ExportDailyCashFlowReportRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace Fluxus.WebApi.Features.CashFlows.DailyCashFlow.Reports
+{
+    public class ExportDailyCashFlowReportRequest
+    {
+        public DateOnly? DateFrom { get; set; }
+        public DateOnly? DateTo { get; set; }
+    }
+}

--- a/src/Fluxus.WebApi/Features/CashFlows/DailyCashFlow/Reports/ExportDailyCashFlowReportResponse.cs
+++ b/src/Fluxus.WebApi/Features/CashFlows/DailyCashFlow/Reports/ExportDailyCashFlowReportResponse.cs
@@ -1,0 +1,9 @@
+﻿namespace Fluxus.WebApi.Features.CashFlows.DailyCashFlow.Reports
+{
+    public class ExportDailyCashFlowReportResponse
+    {
+        public string FileName { get; set; } = string.Empty;
+        public string ContentType { get; set; } = "application/pdf";
+        public byte[] FileContent { get; set; } = [];
+    }
+}

--- a/src/Fluxus.WebApi/Features/CashFlows/DailyCashFlow/Reports/ExportDailyCashFlowReportValidator.cs
+++ b/src/Fluxus.WebApi/Features/CashFlows/DailyCashFlow/Reports/ExportDailyCashFlowReportValidator.cs
@@ -1,0 +1,21 @@
+﻿using FluentValidation;
+
+namespace Fluxus.WebApi.Features.CashFlows.DailyCashFlow.Reports
+{
+    public class ExportDailyCashFlowReportValidator : AbstractValidator<ExportDailyCashFlowReportRequest>
+    {
+        public ExportDailyCashFlowReportValidator()
+        {
+            RuleFor(x => x.DateFrom)
+                .LessThanOrEqualTo(x => x.DateTo)
+                .When(x => x.DateFrom.HasValue && x.DateTo.HasValue)
+                .WithMessage("A data inicial deve ser anterior ou igual à data final.");
+
+            RuleFor(x => x.DateTo)
+                .Null()
+                .When(x => x.DateFrom is null)
+                .WithMessage("A data final não pode ser informada sem uma data inicial.");
+
+        }
+    }
+}

--- a/src/Fluxus.WebApi/Fluxus.WebApi.csproj
+++ b/src/Fluxus.WebApi/Fluxus.WebApi.csproj
@@ -8,12 +8,16 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>..\..</DockerfileContext>
     <DockerComposeProjectPath>..\..\docker-compose.dcproj</DockerComposeProjectPath>
+	<PreserveCompilationContext>true</PreserveCompilationContext>
+	<CopyRefAssembliesToPublishDirectory>true</CopyRefAssembliesToPublishDirectory>
+	<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.10.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="MediatR" Version="12.4.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.14" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.10">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Fluxus.WebApi/Program.cs
+++ b/src/Fluxus.WebApi/Program.cs
@@ -20,6 +20,9 @@ public class Program
 {
     public static async Task Main(string[] args)
     {
+
+        QuestPDF.Settings.License = QuestPDF.Infrastructure.LicenseType.Community;
+
         try
         {
             Log.Information("Starting web application");

--- a/tests/Fluxus.Unit/Application/Features/CashFlows/DailyCashFlow/Reports/GenerateDailyCashFlowReport/GenerateDailyCashFlowReportHandlerTests.cs
+++ b/tests/Fluxus.Unit/Application/Features/CashFlows/DailyCashFlow/Reports/GenerateDailyCashFlowReport/GenerateDailyCashFlowReportHandlerTests.cs
@@ -1,0 +1,58 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using Fluxus.Application.Domain.Repositories;
+using Fluxus.Application.Features.CashFlows.DailyCashFlow.Reports.GenerateDailyCashFlowReport;
+using Fluxus.Common.Reporting.Interfaces;
+using Fluxus.Common.Reporting.Models;
+using Fluxus.UnitTests.Application.TestData;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+using QuestPDF.Infrastructure;
+
+namespace Fluxus.UnitTests.Application.Features.CashFlows.DailyCashFlow.Reports.GenerateDailyCashFlowReport
+{
+    public class GenerateDailyCashFlowReportHandlerTests
+    {
+        private readonly IDailyConsolidationRepository _repository;
+        private readonly IMapper _mapper;
+        private readonly IPdfReportGenerator _pdfReportGenerator;
+        private readonly GenerateDailyCashFlowReportHandler _handler;
+
+        public GenerateDailyCashFlowReportHandlerTests()
+        {
+            _repository = Substitute.For<IDailyConsolidationRepository>();
+            _mapper = Substitute.For<IMapper>();
+            _pdfReportGenerator = Substitute.For<IPdfReportGenerator>();
+            _handler = new GenerateDailyCashFlowReportHandler(_repository, _pdfReportGenerator, _mapper);
+        }
+
+        [Fact]
+        public async Task Should_Generate_Report_With_Filtered_Data()
+        {
+            // Arrange
+            var consolidations = GenerateDailyCashFlowReportTestData.GenerateConsolidations();
+            var query = GenerateDailyCashFlowReportTestData.CreateQueryWithRange();
+            var mappedItems = GenerateDailyCashFlowReportTestData.GenerateMappedReportModels();
+
+            _repository.GetAllByUserAsync(query.UserId, Arg.Any<CancellationToken>())
+                .Returns(consolidations);
+
+            _mapper.Map<List<DailyCashFlowReportModel>>(Arg.Any<List<Domain.Entities.DailyConsolidation>>())
+                .Returns(mappedItems);
+
+            _pdfReportGenerator.GenerateAsync(Arg.Any<IDocument>(), Arg.Any<CancellationToken>())
+                .Returns(new byte[] { 1, 2, 3 });
+
+            // Act
+            var result = await _handler.Handle(query, CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.FileContent.Should().NotBeEmpty();
+            result.FileName.Should().Be("fluxo-caixa-diario.pdf");
+            result.ContentType.Should().Be("application/pdf");
+        }
+    }
+}

--- a/tests/Fluxus.Unit/Application/Features/CashFlows/DailyCashFlow/Reports/GenerateDailyCashFlowReport/GenerateDailyCashFlowReportProfileTests.cs
+++ b/tests/Fluxus.Unit/Application/Features/CashFlows/DailyCashFlow/Reports/GenerateDailyCashFlowReport/GenerateDailyCashFlowReportProfileTests.cs
@@ -1,0 +1,44 @@
+﻿using AutoMapper;
+using Fluxus.Application.Features.CashFlows.DailyCashFlow.Reports.GenerateDailyCashFlowReport;
+using Fluxus.Common.Reporting.Models;
+using Fluxus.UnitTests.Application.TestData;
+using FluentAssertions;
+using Xunit;
+
+namespace Fluxus.UnitTests.Application.Features.CashFlows.Reports.GenerateDailyCashFlowReport
+{
+    public class GenerateDailyCashFlowReportProfileTests
+    {
+        private readonly IMapper _mapper;
+
+        public GenerateDailyCashFlowReportProfileTests()
+        {
+            var config = new MapperConfiguration(cfg =>
+            {
+                cfg.AddProfile<GenerateDailyCashFlowReportProfile>();
+            });
+
+            _mapper = config.CreateMapper();
+        }
+
+        [Fact]
+        public void Should_Map_DailyConsolidation_To_ReportModel()
+        {
+            // Arrange
+            var consolidations = GenerateDailyCashFlowReportTestData.GenerateConsolidations();
+
+            // Act
+            var result = _mapper.Map<List<DailyCashFlowReportModel>>(consolidations);
+
+            // Assert
+            result.Should().HaveCount(consolidations.Count);
+
+            for (int i = 0; i < consolidations.Count; i++)
+            {
+                result[i].Date.Should().Be(consolidations[i].Date);
+                result[i].TotalCredits.Should().Be(consolidations[i].TotalCredits);
+                result[i].TotalDebits.Should().Be(consolidations[i].TotalDebits);
+            }
+        }
+    }
+}

--- a/tests/Fluxus.Unit/Application/TestData/GenerateDailyCashFlowReportTestData.cs
+++ b/tests/Fluxus.Unit/Application/TestData/GenerateDailyCashFlowReportTestData.cs
@@ -1,0 +1,43 @@
+﻿using Bogus;
+using Fluxus.Application.Features.CashFlows.DailyCashFlow.Reports.GenerateDailyCashFlowReport;
+using Fluxus.Common.Reporting.Models;
+using Fluxus.Domain.Entities;
+
+namespace Fluxus.UnitTests.Application.TestData
+{
+    public static class GenerateDailyCashFlowReportTestData
+    {
+        public static readonly Guid UserId = Guid.NewGuid();
+
+        public static List<DailyConsolidation> GenerateConsolidations()
+        {
+            return new List<DailyConsolidation>
+            {
+                new() { Id = Guid.NewGuid(), UserId = UserId, Date = new DateOnly(2025, 03, 01), TotalCredits = 100, TotalDebits = 30 },
+                new() { Id = Guid.NewGuid(), UserId = UserId, Date = new DateOnly(2025, 03, 02), TotalCredits = 150, TotalDebits = 50 },
+                new() { Id = Guid.NewGuid(), UserId = UserId, Date = new DateOnly(2025, 03, 03), TotalCredits = 80, TotalDebits = 60 }
+            };
+        }
+
+        public static GenerateDailyCashFlowReportQuery CreateQueryWithRange()
+        {
+            return new GenerateDailyCashFlowReportQuery
+            {
+                UserId = UserId,
+                DateFrom = new DateOnly(2025, 03, 01),
+                DateTo = new DateOnly(2025, 03, 03)
+            };
+        }
+
+        public static List<DailyCashFlowReportModel> GenerateMappedReportModels()
+        {
+            var faker = new Faker<DailyCashFlowReportModel>()
+                .RuleFor(m => m.Date, f => new DateOnly(2025, 03, f.Random.Int(1, 3)))
+                .RuleFor(m => m.TotalCredits, f => f.Finance.Amount(50, 200))
+                .RuleFor(m => m.TotalDebits, f => f.Finance.Amount(10, 100))
+                .RuleFor(m => m.AccumulatedBalance, 0);
+
+            return faker.Generate(3).OrderBy(x => x.Date).ToList();
+        }
+    }
+}


### PR DESCRIPTION
## Pull Request — Exportação de Relatório Diário em PDF

### Descrição

Esta PR implementa a funcionalidade completa de **exportação de relatório de fluxo de caixa diário em formato PDF**, utilizando a biblioteca **QuestPDF**, com foco em modularidade, desacoplamento e reutilização.

A implementação segue a arquitetura já consolidada do projeto, com camadas bem definidas e componentes reaproveitáveis em futuras funcionalidades.

---

### Funcionalidades implementadas

- [x] Geração de relatório de **consolidação diária** com base em filtros de data (`DateFrom` e `DateTo`)
- [x] Utilização de `QuestPDF` com layout estruturado por componentes (`DailyCashFlowReportDocument` e `DailyCashFlowTableComponent`)
- [x] Introdução de constantes para metadados do relatório (título, nome do arquivo, etc.)
- [x] Camada comum (`Fluxus.Common.Reporting`) preparada para suportar múltiplos relatórios no futuro
- [x] Atualização dos mapeamentos com `AutoMapper`
- [x] Inclusão do novo controller `CashFlowReportController` para exportação

---

### Testes unitários

- [x] `GenerateDailyCashFlowReportHandlerTests` cobrindo:
  - Geração completa do PDF com range de datas
  - Mapeamento correto dos dados e cálculo do saldo acumulado
- [x] `GenerateDailyCashFlowReportProfileTests` garantindo o mapeamento entre `DailyConsolidation` e `DailyCashFlowReportModel`

---

### Limpeza de legado

- [x] Remoção da dependência da antiga biblioteca `DinkToPdf`
- [x] Eliminação do template `.cshtml` não utilizado
- [x] Exclusão de arquivos não utilizados da estratégia anterior