### PR TITLE
test(webapi): adiciona testes unitários para todos os controllers

### DIFF
--- a/tests/Fluxus.Unit/Fluxus.Unit.csproj
+++ b/tests/Fluxus.Unit/Fluxus.Unit.csproj
@@ -9,6 +9,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit" Version="2.9.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -36,6 +37,7 @@
 		<ProjectReference Include="..\..\src\Fluxus.Domain\Fluxus.Domain.csproj" />
 		<ProjectReference Include="..\..\src\Fluxus.Application\Fluxus.Application.csproj" />
 		<ProjectReference Include="..\..\src\Fluxus.ORM\Fluxus.ORM.csproj" />
+		<ProjectReference Include="..\..\src\Fluxus.WebApi\Fluxus.WebApi.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/tests/Fluxus.Unit/WebApi/Controllers/AuthControllerTests.cs
+++ b/tests/Fluxus.Unit/WebApi/Controllers/AuthControllerTests.cs
@@ -1,0 +1,89 @@
+﻿using Xunit;
+using Moq;
+using AutoMapper;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Fluxus.WebApi.Features.Auth;
+using Fluxus.WebApi.Features.Auth.AuthenticateUserFeature;
+using Fluxus.Application.Features.Auth.AuthenticateUser;
+using System.Threading;
+using FluentValidation.Results;
+using Fluxus.WebApi.Common;
+
+namespace Fluxus.Unit.WebApi.Controllers;
+
+public class AuthControllerTests
+{
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<IMapper> _mapperMock;
+    private readonly AuthController _controller;
+
+    public AuthControllerTests()
+    {
+        _mediatorMock = new Mock<IMediator>();
+        _mapperMock = new Mock<IMapper>();
+        _controller = new AuthController(_mediatorMock.Object, _mapperMock.Object);
+    }
+
+    [Fact]
+    public async Task AuthenticateUser_ShouldReturnOk_WhenValidRequest()
+    {
+        // Arrange
+        var request = new AuthenticateUserRequest
+        {
+            Email = "user@email.com",
+            Password = "123456"
+        };
+
+        var command = new AuthenticateUserCommand();
+        var result = new AuthenticateUserResult();
+        var response = new AuthenticateUserResponse();
+
+        _mapperMock.Setup(m => m.Map<AuthenticateUserCommand>(request)).Returns(command);
+        _mediatorMock.Setup(m => m.Send(command, It.IsAny<CancellationToken>())).ReturnsAsync(result);
+        _mapperMock.Setup(m => m.Map<AuthenticateUserResponse>(result)).Returns(response);
+
+        // Act
+        var actionResult = await _controller.AuthenticateUser(request, default);
+        var okResult = actionResult as OkObjectResult;
+
+        // Assert
+        okResult.Should().NotBeNull("esperamos um OkObjectResult");
+        okResult!.Value.Should().NotBeNull("esperamos um corpo de resposta");
+
+        // Desempacotando o nível duplo de resposta
+        var outer = okResult.Value as ApiResponseWithData<ApiResponseWithData<AuthenticateUserResponse>>;
+        outer.Should().NotBeNull("esperamos um ApiResponseWithData<ApiResponseWithData<T>>");
+        outer!.Success.Should().BeTrue();
+
+        var inner = outer.Data;
+        inner.Should().NotBeNull();
+        inner!.Data.Should().Be(response);
+    }
+
+    [Fact]
+    public async Task AuthenticateUser_ShouldReturnBadRequest_WhenValidationFails()
+    {
+        // Arrange
+        var request = new AuthenticateUserRequest
+        {
+            Email = "",
+            Password = ""
+        };
+
+        // Act
+        var result = await _controller.AuthenticateUser(request, default);
+        var badRequestResult = result as BadRequestObjectResult;
+
+        // Assert
+        badRequestResult.Should().NotBeNull();
+        badRequestResult!.StatusCode.Should().Be(400);
+
+        var errors = badRequestResult.Value as IEnumerable<ValidationFailure>;
+        errors.Should().NotBeNull();
+        errors!.Count().Should().BeGreaterOrEqualTo(2);
+        errors.Should().Contain(e => e.PropertyName == "Email");
+        errors.Should().Contain(e => e.PropertyName == "Password");
+    }
+}

--- a/tests/Fluxus.Unit/WebApi/Controllers/CashFlowControllerTests.cs
+++ b/tests/Fluxus.Unit/WebApi/Controllers/CashFlowControllerTests.cs
@@ -1,0 +1,67 @@
+﻿using Xunit;
+using Moq;
+using FluentAssertions;
+using AutoMapper;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Fluxus.WebApi.Features.CashFlows;
+using Fluxus.Application.Features.CashFlows.DailyCashFlow;
+using Fluxus.WebApi.Features.CashFlows.DailyCashFlow;
+using System.Security.Claims;
+using Fluxus.WebApi.Common;
+
+namespace Fluxus.Unit.WebApi.Controllers;
+
+public class CashFlowControllerTests
+{
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<IMapper> _mapperMock;
+    private readonly CashFlowController _controller;
+
+    public CashFlowControllerTests()
+    {
+        _mediatorMock = new Mock<IMediator>();
+        _mapperMock = new Mock<IMapper>();
+        _controller = new CashFlowController(_mediatorMock.Object, _mapperMock.Object);
+
+        var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] {
+            new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString())
+        }));
+
+        _controller.ControllerContext = new ControllerContext()
+        {
+            HttpContext = new DefaultHttpContext() { User = user }
+        };
+    }
+
+    [Fact]
+    public async Task GetDailyCashFlow_ShouldReturnOk_WithListOfResponses()
+    {
+        // Arrange
+        var request = new DailyCashFlowRequest
+        {
+            DateFrom = DateOnly.FromDateTime(DateTime.Today.AddDays(-1)),
+            DateTo = DateOnly.FromDateTime(DateTime.Today)
+        };
+
+        var query = new DailyCashFlowQuery();
+        var result = new List<DailyCashFlowResult> { new() };
+        var response = new List<DailyCashFlowResponse> { new() };
+
+        _mapperMock.Setup(m => m.Map<DailyCashFlowQuery>(request)).Returns(query);
+        _mediatorMock.Setup(m => m.Send(query, default)).ReturnsAsync(result);
+        _mapperMock.Setup(m => m.Map<List<DailyCashFlowResponse>>(result)).Returns(response);
+
+        // Act
+        var actionResult = await _controller.GetDailyCashFlow(request, default);
+        var okResult = actionResult as OkObjectResult;
+
+        // Assert
+        okResult.Should().NotBeNull();
+        okResult!.Value.Should().BeOfType<ApiResponseWithData<List<DailyCashFlowResponse>>>();
+        var data = okResult.Value as ApiResponseWithData<List<DailyCashFlowResponse>>;
+        data!.Success.Should().BeTrue();
+        data.Data.Should().BeEquivalentTo(response);
+    }
+}

--- a/tests/Fluxus.Unit/WebApi/Controllers/CashFlowReportControllerTests.cs
+++ b/tests/Fluxus.Unit/WebApi/Controllers/CashFlowReportControllerTests.cs
@@ -1,0 +1,114 @@
+﻿using Xunit;
+using Moq;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Fluxus.WebApi.Features.CashFlows.Reports;
+using Fluxus.Application.Features.CashFlows.DailyCashFlow.Reports.GenerateDailyCashFlowReport;
+using Fluxus.Common.Security.Interfaces;
+using Fluxus.Common.Reporting.Constants;
+using Fluxus.WebApi.Features.CashFlows.DailyCashFlow.Reports;
+
+namespace Fluxus.Unit.WebApi.Controllers;
+
+public class CashFlowReportControllerTests
+{
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<IAuthenticatedUser> _userMock;
+    private readonly CashFlowReportController _controller;
+
+    public CashFlowReportControllerTests()
+    {
+        _mediatorMock = new Mock<IMediator>();
+        _userMock = new Mock<IAuthenticatedUser>();
+        _controller = new CashFlowReportController(_mediatorMock.Object, _userMock.Object);
+    }
+
+    [Fact]
+    public async Task Export_ShouldReturnFile_WhenSuccess()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var request = new ExportDailyCashFlowReportRequest
+        {
+            DateFrom = DateOnly.FromDateTime(DateTime.Today.AddDays(-1)),
+            DateTo = DateOnly.FromDateTime(DateTime.Today)
+        };
+
+        var result = new GenerateDailyCashFlowReportResult
+        {
+            FileContent = new byte[] { 1, 2, 3 },
+            ContentType = "application/pdf",
+            FileName = "relatorio.pdf"
+        };
+
+        _userMock.Setup(x => x.Id).Returns(userId);
+        _mediatorMock.Setup(m => m.Send(It.IsAny<GenerateDailyCashFlowReportQuery>(), default))
+                     .ReturnsAsync(result);
+
+        // Act
+        var response = await _controller.Export(request, default);
+
+        // Assert
+        response.Should().BeOfType<FileContentResult>();
+        var file = response as FileContentResult;
+        file!.ContentType.Should().Be("application/pdf");
+        file.FileDownloadName.Should().Be("relatorio.pdf");
+        file.FileContents.Should().BeEquivalentTo(result.FileContent);
+    }
+
+    [Fact]
+    public async Task Export_ShouldReturn504_WhenTimeout()
+    {
+        // Arrange
+        _userMock.Setup(x => x.Id).Returns(Guid.NewGuid());
+        _mediatorMock.Setup(m => m.Send(It.IsAny<GenerateDailyCashFlowReportQuery>(), default))
+                     .ThrowsAsync(new TaskCanceledException());
+
+        var request = new ExportDailyCashFlowReportRequest
+        {
+            DateFrom = DateOnly.FromDateTime(DateTime.Today.AddDays(-1)),
+            DateTo = DateOnly.FromDateTime(DateTime.Today)
+        };
+
+        // Act
+        var response = await _controller.Export(request, default) as ObjectResult;
+
+        // Assert
+        response.Should().NotBeNull();
+        response!.StatusCode.Should().Be(504);
+        response.Value.Should().BeEquivalentTo(new
+        {
+            success = false,
+            message = ReportMessages.TimeoutError
+        });
+    }
+
+    [Fact]
+    public async Task Export_ShouldReturn500_WhenUnhandledError()
+    {
+        // Arrange
+        _userMock.Setup(x => x.Id).Returns(Guid.NewGuid());
+        _mediatorMock.Setup(m => m.Send(It.IsAny<GenerateDailyCashFlowReportQuery>(), default))
+                     .ThrowsAsync(new Exception("Algo deu errado"));
+
+        var request = new ExportDailyCashFlowReportRequest
+        {
+            DateFrom = DateOnly.FromDateTime(DateTime.Today.AddDays(-1)),
+            DateTo = DateOnly.FromDateTime(DateTime.Today)
+        };
+
+        // Act
+        var response = await _controller.Export(request, default) as ObjectResult;
+
+        // Assert
+        response.Should().NotBeNull();
+        response!.StatusCode.Should().Be(500);
+        response.Value.Should().BeEquivalentTo(new
+        {
+            success = false,
+            message = ReportMessages.UnexpectedError,
+            detail = "Algo deu errado"
+        });
+    }
+}

--- a/tests/Fluxus.Unit/WebApi/Controllers/TransactionsControllerTests.cs
+++ b/tests/Fluxus.Unit/WebApi/Controllers/TransactionsControllerTests.cs
@@ -1,0 +1,115 @@
+﻿using Xunit;
+using Moq;
+using AutoMapper;
+using MediatR;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Fluxus.WebApi.Features.Transactions;
+using Fluxus.Application.Features.Transactions.CreateTransaction;
+using Fluxus.Application.Features.Transactions.ListTransactions;
+using Fluxus.Application.Features.Consolidations.ListDailyConsolidation;
+using Fluxus.WebApi.Features.Transactions.CreateTransactionFeature;
+using Fluxus.WebApi.Features.Transactions.ListTransactionsFeature;
+using Fluxus.WebApi.Features.Consolidations.ListDailyConsolidation;
+using System.Security.Claims;
+using Fluxus.WebApi.Common;
+
+namespace Fluxus.Unit.WebApi.Controllers;
+
+public class TransactionsControllerTests
+{
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<IMapper> _mapperMock;
+    private readonly TransactionController _controller;
+
+    public TransactionsControllerTests()
+    {
+        _mediatorMock = new Mock<IMediator>();
+        _mapperMock = new Mock<IMapper>();
+        _controller = new TransactionController(_mediatorMock.Object, _mapperMock.Object);
+
+        var user = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString())
+        }));
+
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = user }
+        };
+    }
+
+    [Fact]
+    public async Task Create_ShouldReturnOk_WhenTransactionIsCreated()
+    {
+        // Arrange
+        var request = new CreateTransactionRequest { Amount = 100, Description = "Teste", Type = 0 };
+        var command = new CreateTransactionCommand();
+        var result = new CreateTransactionResult();
+        var response = new CreateTransactionResponse();
+
+        _mapperMock.Setup(m => m.Map<CreateTransactionCommand>(request)).Returns(command);
+        _mediatorMock.Setup(m => m.Send(It.IsAny<CreateTransactionCommand>(), default)).ReturnsAsync(result);
+        _mapperMock.Setup(m => m.Map<CreateTransactionResponse>(result)).Returns(response);
+
+        // Act
+        var actionResult = await _controller.Create(request);
+        var okResult = actionResult as OkObjectResult;
+
+        // Assert
+        okResult.Should().NotBeNull();
+        okResult!.Value.Should().BeOfType<ApiResponseWithData<CreateTransactionResponse>>();
+        var data = okResult.Value as ApiResponseWithData<CreateTransactionResponse>;
+        data!.Success.Should().BeTrue();
+        data.Data.Should().Be(response);
+    }
+
+    [Fact]
+    public async Task GetAll_ShouldReturnOk_WithTransactionList()
+    {
+        // Arrange
+        var request = new ListTransactionsRequest();
+        var query = new ListTransactionsQuery();
+        var result = new List<ListTransactionsResult> { new() };
+
+        _mapperMock.Setup(m => m.Map<ListTransactionsQuery>(request)).Returns(query);
+        _mediatorMock.Setup(m => m.Send(query, default)).ReturnsAsync(result);
+
+        // Act
+        var actionResult = await _controller.GetAll(request, default);
+        var okResult = actionResult as OkObjectResult;
+
+        // Assert
+        okResult.Should().NotBeNull();
+        okResult!.Value.Should().BeOfType<ApiResponseWithData<List<ListTransactionsResult>>>();
+        var data = okResult.Value as ApiResponseWithData<List<ListTransactionsResult>>;
+        data!.Success.Should().BeTrue();
+        data.Data.Should().BeEquivalentTo(result);
+    }
+
+    [Fact]
+    public async Task GetConsolidation_ShouldReturnOk_WithConsolidationData()
+    {
+        // Arrange
+        var request = new ListDailyConsolidationRequest();
+        var query = new ListDailyConsolidationQuery();
+        var result = new List<ListDailyConsolidationResult> { new() };
+        var response = new List<ListDailyConsolidationResponse> { new() };
+
+        _mapperMock.Setup(m => m.Map<ListDailyConsolidationQuery>(request)).Returns(query);
+        _mediatorMock.Setup(m => m.Send(query, default)).ReturnsAsync(result);
+        _mapperMock.Setup(m => m.Map<IEnumerable<ListDailyConsolidationResponse>>(result)).Returns(response);
+
+        // Act
+        var actionResult = await _controller.GetConsolidation(request, default);
+        var okResult = actionResult as OkObjectResult;
+
+        // Assert
+        okResult.Should().NotBeNull();
+        okResult!.Value.Should().BeOfType<ApiResponseWithData<IEnumerable<ListDailyConsolidationResponse>>>();
+        var data = okResult.Value as ApiResponseWithData<IEnumerable<ListDailyConsolidationResponse>>;
+        data!.Success.Should().BeTrue();
+        data.Data.Should().BeEquivalentTo(response);
+    }
+}


### PR DESCRIPTION
## Descrição

Esta PR adiciona cobertura de **testes unitários** para todos os **controllers** da camada WebApi, garantindo a qualidade e previsibilidade das respostas da API.

Controllers cobertos:

- `AuthController`
- `TransactionController`
- `CashFlowController`
- `CashFlowReportController`

---

## Detalhes técnicos

- Utilização de **xUnit**, **Moq** e **FluentAssertions**
- Simulação de `IMediator`, `IMapper` e `IAuthenticatedUser`
- Mock de `HttpContext` para injeção de `UserId` quando necessário
- Cobertura de cenários de sucesso e falhas (como exceções, validações, timeouts)
- Correção dos testes com base no comportamento do `BaseController`, que encapsula as respostas em `ApiResponseWithData<T>`

---

## Testes implementados

- Autenticação com e sem falhas de validação
- Criação de transações e listagem
- Consolidação de lançamentos
- Relatório de fluxo de caixa em PDF
- Tolerância a falhas e retornos HTTP apropriados (500 / 504)

---

## Observações

- Essa PR finaliza a cobertura unitária da camada WebApi
- Todos os testes foram executados com sucesso
- Próxima etapa sugerida: otimizações de escalabilidade e documentação técnica final
