### PR TITLE
feat(report): implementa escalabilidade e tolerância a falhas no endpoint de relatório em PDF

### DIFF
--- a/tests/Fluxus.Unit/WebApi/Controllers/CashFlowReportControllerTests.cs
+++ b/tests/Fluxus.Unit/WebApi/Controllers/CashFlowReportControllerTests.cs
@@ -7,6 +7,7 @@ using Fluxus.WebApi.Features.CashFlows.Reports;
 using Fluxus.Application.Features.CashFlows.DailyCashFlow.Reports.GenerateDailyCashFlowReport;
 using Fluxus.Common.Security.Interfaces;
 using Fluxus.Common.Reporting.Constants;
+using Microsoft.Extensions.Caching.Memory;
 using Fluxus.WebApi.Features.CashFlows.DailyCashFlow.Reports;
 
 namespace Fluxus.Unit.WebApi.Controllers;
@@ -15,13 +16,15 @@ public class CashFlowReportControllerTests
 {
     private readonly Mock<IMediator> _mediatorMock;
     private readonly Mock<IAuthenticatedUser> _userMock;
+    private readonly Mock<IMemoryCache> _cacheMock;
     private readonly CashFlowReportController _controller;
 
     public CashFlowReportControllerTests()
     {
         _mediatorMock = new Mock<IMediator>();
         _userMock = new Mock<IAuthenticatedUser>();
-        _controller = new CashFlowReportController(_mediatorMock.Object, _userMock.Object);
+        _cacheMock = new Mock<IMemoryCache>();
+        _controller = new CashFlowReportController(_mediatorMock.Object, _userMock.Object, _cacheMock.Object);
     }
 
     [Fact]
@@ -43,8 +46,12 @@ public class CashFlowReportControllerTests
         };
 
         _userMock.Setup(x => x.Id).Returns(userId);
+        _cacheMock.Setup(c => c.TryGetValue(It.IsAny<object>(), out It.Ref<object>.IsAny)).Returns(false);
         _mediatorMock.Setup(m => m.Send(It.IsAny<GenerateDailyCashFlowReportQuery>(), default))
                      .ReturnsAsync(result);
+
+        var cacheEntry = new Mock<ICacheEntry>();
+        _cacheMock.Setup(c => c.CreateEntry(It.IsAny<object>())).Returns(cacheEntry.Object);
 
         // Act
         var response = await _controller.Export(request, default);
@@ -62,6 +69,7 @@ public class CashFlowReportControllerTests
     {
         // Arrange
         _userMock.Setup(x => x.Id).Returns(Guid.NewGuid());
+        _cacheMock.Setup(c => c.TryGetValue(It.IsAny<object>(), out It.Ref<object>.IsAny)).Returns(false);
         _mediatorMock.Setup(m => m.Send(It.IsAny<GenerateDailyCashFlowReportQuery>(), default))
                      .ThrowsAsync(new TaskCanceledException());
 
@@ -89,6 +97,7 @@ public class CashFlowReportControllerTests
     {
         // Arrange
         _userMock.Setup(x => x.Id).Returns(Guid.NewGuid());
+        _cacheMock.Setup(c => c.TryGetValue(It.IsAny<object>(), out It.Ref<object>.IsAny)).Returns(false);
         _mediatorMock.Setup(m => m.Send(It.IsAny<GenerateDailyCashFlowReportQuery>(), default))
                      .ThrowsAsync(new Exception("Algo deu errado"));
 
@@ -110,5 +119,72 @@ public class CashFlowReportControllerTests
             message = ReportMessages.UnexpectedError,
             detail = "Algo deu errado"
         });
+    }
+
+    [Fact]
+    public async Task Export_ShouldReturnCachedResult_WhenExistsInCache()
+    {
+        // Arrange
+        var request = new ExportDailyCashFlowReportRequest
+        {
+            DateFrom = DateOnly.FromDateTime(DateTime.Today.AddDays(-1)),
+            DateTo = DateOnly.FromDateTime(DateTime.Today)
+        };
+
+        var userId = Guid.NewGuid();
+        var expectedResult = new FileContentResult(new byte[] { 1, 2, 3 }, "application/pdf")
+        {
+            FileDownloadName = "relatorio.pdf"
+        };
+
+        object dummyOut = expectedResult;
+
+        _userMock.Setup(u => u.Id).Returns(userId);
+        _cacheMock.Setup(c => c.TryGetValue(It.IsAny<object>(), out dummyOut)).Returns(true);
+
+        // Act
+        var result = await _controller.Export(request, default);
+
+        // Assert
+        result.Should().BeSameAs(expectedResult);
+        _mediatorMock.Verify(m => m.Send(It.IsAny<GenerateDailyCashFlowReportQuery>(), default), Times.Never);
+    }
+
+    [Fact]
+    public async Task Export_ShouldCacheResult_WhenGenerated()
+    {
+        // Arrange
+        var request = new ExportDailyCashFlowReportRequest
+        {
+            DateFrom = DateOnly.FromDateTime(DateTime.Today.AddDays(-2)),
+            DateTo = DateOnly.FromDateTime(DateTime.Today.AddDays(-1))
+        };
+
+        var userId = Guid.NewGuid();
+        var result = new GenerateDailyCashFlowReportResult
+        {
+            FileContent = new byte[] { 9, 8, 7 },
+            ContentType = "application/pdf",
+            FileName = "relatorio_gerado.pdf"
+        };
+
+        _userMock.Setup(u => u.Id).Returns(userId);
+        _cacheMock.Setup(c => c.TryGetValue(It.IsAny<object>(), out It.Ref<object>.IsAny)).Returns(false);
+        _mediatorMock.Setup(m => m.Send(It.IsAny<GenerateDailyCashFlowReportQuery>(), default)).ReturnsAsync(result);
+
+        var cacheEntryMock = new Mock<ICacheEntry>();
+        _cacheMock.Setup(c => c.CreateEntry(It.IsAny<object>())).Returns(cacheEntryMock.Object);
+
+        // Act
+        var response = await _controller.Export(request, default);
+
+        // Assert
+        var fileResult = response as FileContentResult;
+        fileResult.Should().NotBeNull();
+        fileResult!.FileContents.Should().BeEquivalentTo(result.FileContent);
+        fileResult.ContentType.Should().Be(result.ContentType);
+        fileResult.FileDownloadName.Should().Be(result.FileName);
+
+        _cacheMock.Verify(c => c.CreateEntry(It.IsAny<object>()), Times.Once);
     }
 }


### PR DESCRIPTION
## Descrição

Esta PR entrega uma implementação completa de **escalabilidade e resiliência** para o endpoint de exportação do relatório de fluxo de caixa diário em PDF.

---

## Funcionalidades implementadas

### Rate Limiting (ASP.NET Core 8)
- Configurado com limite de 50 requisições por segundo
- Fila de até 5 requisições
- Protege o endpoint `/api/cashflowreport/daily/report` contra sobrecarga

### Cache em memória (`IMemoryCache`)
- Armazena `FileContentResult` gerado por até 5 minutos
- Chaveada por `userId`, `DateFrom` e `DateTo`
- Evita reprocessamento de relatórios repetidos
- Fácil substituição futura por cache distribuído (ex: Redis)

### Tolerância a falhas
- `504 Gateway Timeout` em caso de `TaskCanceledException`
- `500 Internal Server Error` com mensagem e `detail` para falhas inesperadas
- Garante robustez mesmo quando há sobrecarga ou erro interno

---

## Testes unitários implementados

**Arquivo:** `CashFlowReportControllerTests.cs`

- ✅ `Export_ShouldReturnFile_WhenSuccess`
- ✅ `Export_ShouldReturn504_WhenTimeout`
- ✅ `Export_ShouldReturn500_WhenUnhandledError`
- ✅ `Export_ShouldReturnCachedResult_WhenExistsInCache`
- ✅ `Export_ShouldCacheResult_WhenGenerated`

Mock de `IMemoryCache` com verificação de `TryGetValue` e `CreateEntry`.

---

## Detalhes técnicos

- Injeção de `IMemoryCache` e `IAuthenticatedUser` no controller
- Chave de cache padronizada: `pdf:{userId}:{DateFrom}:{DateTo}`
- Resposta rápida e previsível, mesmo sob carga
- Arquitetura permanece limpa, testável e extensível

---

## Resultados esperados

- Tempo de resposta reduzido em chamadas repetidas
- Redução de carga no banco e processamento de PDF
- Garantia de funcionamento contínuo, mesmo com falhas intermitentes